### PR TITLE
downloadcsv.js: try to explain firefox issue where nothing happens

### DIFF
--- a/Download table as CSV/downloadcsv.js
+++ b/Download table as CSV/downloadcsv.js
@@ -1,6 +1,11 @@
 (function() {
 	"use strict";
-	let clickedEl = document.getSelection().focusNode.parentElement;
+	let selected = document.getSelection();
+	if (!selected.focusNode) {
+		alert("No HTML table was found focus point. Try clicking inside the table and try again.");
+		return;
+	}
+	let clickedEl = selected.focusNode.parentElement;
 	let table = clickedEl.closest("table");		
 	if(table === null){
 		alert("No HTML table was found");


### PR DESCRIPTION
This commit demonstrates workaround for issue arktiv/table-csv-chrome#4

When run on firefox, it presents an alert message attempting to explain to the user how to work around the issue, by clicking to set the caret/cursor location.

I've tried a number of alternative approaches and not succeded.

In firefox (not chrome) there is supposed to be the required information in the `onClicked` event as `item.targetElementId`, but that seems to turn out null also, irrespective of whether the caret is set or not.

Alternatively I tried to add a `contextMenus.onShow` handler to disable (grey-out) the entry if the caret is not set, by injecting `focusNode` checking into the content page.

```
chrome.tabs.executeScript(tab.id, {
  frameId: item.frameId,
  code: "document.getSelection().focusNode != null;"},
  function(result) {
    chrome.contextMenus.update("DLCSV", {enabled: result[0]});
  });
```

This works only in the `onClick` handler (the wrong place), and hits permission issues in the `onShow` handler.  I can't tell yet if this is a firefox bug/misfeature, or something about the `activeTab` permission I don't understand.