### PR TITLE
Support UTF-8 with BOM.

### DIFF
--- a/Download table as CSV/downloadcsv.js
+++ b/Download table as CSV/downloadcsv.js
@@ -32,7 +32,8 @@
 		let fileName = prompt("File name: ", (table.id || table.id.length > 0) ? table.id : "table");
 		if(fileName == null) return;			
 		downloadLink.download = fileName != "" ? fileName + ".csv" : "table.csv"
-		downloadLink.href = window.URL.createObjectURL(new Blob([csv.join("\r\n")], {type: "text/csv"}));
+		const bom = "\uFEFF";
+		downloadLink.href = window.URL.createObjectURL(new Blob([bom, csv.join("\r\n")], {type: "text/csv"}));
 		downloadLink.style.display = "none";
 		document.body.appendChild(downloadLink);
 		downloadLink.click();	


### PR DESCRIPTION
Hi there.

This patch make table-csv to support UTF-8 with BOM.
For detail, See the following StackOverflow:
- https://stackoverflow.com/questions/42462764/javascript-export-csv-encoding-utf-8-issue
- https://stackoverflow.com/questions/56154046/downloading-blob-with-type-text-csv-strips-unicode-bom

### Background

In multi-byte language like Japanese, we couldn't open the CSV of UTF-8 without BOM. At the moment,  we cannot open the csv by generating Download table as CSV.
