### PR TITLE
Migrate to Chorome Extension manifest v3

### DIFF
--- a/Download table as CSV/manifest.json
+++ b/Download table as CSV/manifest.json
@@ -2,12 +2,11 @@
 	"name": "Download table as CSV",
 	"description": "Download HTML tables in MS Excel style CSV format.",
 	"version": "1.6",
-	"manifest_version": 2,
-	"permissions": ["contextMenus", "activeTab", "storage"],
+	"manifest_version": 3,
+	"permissions": ["contextMenus", "activeTab", "storage", "scripting"],
 	"background": {
-		"scripts": ["background.js"],
-		"persistent": false
-	},"browser_action": {
+		"service_worker": "background.js"
+	},"action": {
 		"default_popup": "popup.html"
 	},
 	"icons": {

--- a/Download table as CSV/manifest.json
+++ b/Download table as CSV/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Download table as CSV",
 	"description": "Download HTML tables in MS Excel style CSV format.",
-	"version": "1.6",
+	"version": "1.7",
 	"manifest_version": 3,
 	"permissions": ["contextMenus", "activeTab", "storage", "scripting"],
 	"background": {

--- a/Download table as CSV/popup.js
+++ b/Download table as CSV/popup.js
@@ -2,7 +2,10 @@
 	"use strict";
 	document.getElementById("downloadTableAsCSVButton").addEventListener("click", ()=>{
 		chrome.tabs.query({active: true, currentWindow: true}, (tabs)=> {
-			chrome.tabs.executeScript(tabs[0].id, {file: "downloadcsv.js", allFrames:true});
+			chrome.scripting.executeScript({
+				target: { tabId: tabs[0].id, allFrames: true },
+				files: ["downloadcsv.js"]
+			});
 		});
 		window.close();
 	});


### PR DESCRIPTION
A few places in the manifest v3 need to be changed. 
Request permission for scripting in order use new scripting API.

I have only tested the updated extension on Chrome.
